### PR TITLE
Hook is added, we need to put in the deploydata(outputs) for removal

### DIFF
--- a/carton/deploy.go
+++ b/carton/deploy.go
@@ -26,6 +26,19 @@ import (
 	"github.com/megamsys/megamd/provision"
 )
 
+type DeployData struct {
+	BoxName     string
+	HookId      string
+	PrivateIp   string
+	PublicIp    string
+	Timestamp   time.Time
+	Duration    time.Duration
+	Commit      string
+	Image       string
+	Origin      string
+	CanRollback bool
+}
+
 type DeployOpts struct {
 	B     *provision.Box
 	Image string //why this image ?
@@ -71,6 +84,27 @@ func saveDeployData(opts *DeployOpts, imageId, dlog string, duration time.Durati
 	// deploy :
 	//     name:
 	//     status:
+
+	/*deploy := DeployData {
+		App:       opts.App.Name,
+		Timestamp: time.Now(),
+		Duration:  duration,
+		Commit:    opts.Commit,
+		Image:     imageId,
+		Log:       log,
+	}
+	if opts.Commit != "" {
+		deploy.Origin = "git"
+	} else if opts.Image != "" {
+		deploy.Origin = "rollback"
+	} else {
+		deploy.Origin = "app-deploy"
+	}
+	if deployError != nil {
+		deploy.Error = deployError.Error()
+	}
+	return db.Store(compid or assmid, &struct)
+	*/
 	return nil
 }
 

--- a/cmd/megamd/run/command_test.go
+++ b/cmd/megamd/run/command_test.go
@@ -12,7 +12,7 @@
 ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ** See the License for the specific language governing permissions and
 ** limitations under the License.
-*/
+ */
 package run
 
 import (
@@ -20,14 +20,10 @@ import (
 	"gopkg.in/check.v1"
 )
 
-type S struct{}
-
-var _ = check.Suite(&S{})
-
 func (s *S) TestMegamStartInfo(c *check.C) {
-	desc := `starts the megamd daemon.
+	desc := `starts megamd.
 
-If you use the '--dry' flag megamd will do a dry run(parse conf/jsons) and exit.
+If you use the '--dry' flag megamd will do a dry run(parse conf) and exit.
 
 `
 

--- a/cmd/megamd/run/config.go
+++ b/cmd/megamd/run/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Deployd *deployd.Config `toml:"deployd"`
 	HTTPD   *httpd.Config   `toml:"http"`
 	Docker  *docker.Config  `toml:"docker"`
+	Bridges *docker.Bridges `toml:bridges`
 	DNS     *dns.Config     `toml:"dns"`
 }
 
@@ -23,18 +24,19 @@ func (c Config) String() string {
 		c.Meta.String() +
 		c.Deployd.String() + "\n" +
 		c.HTTPD.String() + "\n" +
-		c.Docker.String())
+		c.Docker.String() + "\n" +
+		c.Bridges.String())
+
 }
 
 // NewConfig returns an instance of Config with reasonable defaults.
 func NewConfig() *Config {
 	c := &Config{}
 	c.Meta = meta.NewConfig()
-
 	c.Deployd = deployd.NewConfig()
 	c.HTTPD = httpd.NewConfig()
 	c.Docker = docker.NewConfig()
-
+	c.Bridges = docker.NewBridgeConfig()
 	c.DNS = dns.NewConfig()
 	return c
 }

--- a/cmd/megamd/run/config_test.go
+++ b/cmd/megamd/run/config_test.go
@@ -1,55 +1,24 @@
 package run
 
 import (
+	"fmt"
 	"github.com/BurntSushi/toml"
 	"gopkg.in/check.v1"
+	"os/user"
 )
-
 
 // Ensure the configuration can be parsed.
 func (s *S) TestConfig_Parse(c *check.C) {
-	// Parse configuration.
-	var cm Config
-	if _, err := toml.Decode(`
-		[meta]
-			debug = true
-			hostname = "localhost"
-			bind_address = ":9999"
-			dir = "/var/lib/megam/megamd/meta"
-			riak = "192.168.1.100:8087"
-			api  = "https://api.megam.io/v2"
-			amqp = "amqp://guest:guest@192.168.1.100:5672/"
-
-		[deployd]
-			one_endpoint = "http://192.168.1.100:3030/xmlrpc2"
-			one_userid = "oneadmin"
-			one_password =  "password"
-
-		[http]
-	    enabled = true
-	    bind-address = "localhost:6666"
-
-	  [docker]
-	    enabled = false
-	    master = [ http://192.168.1.241:2375 ]
-
-    [docker.public]
-       name="megdock_pub"
-       network = 103.56.93.1/24
-       gateway = 103.56.92.1
-
-   [dns]
-	    enabled = true
-	    route53_access_key = "accesskey"
-	    route53_secret_key = "secretkey"
-`, &cm); err != nil {
-		c.Fatal(err)
+  var cm Config
+	u, _ := user.Current()
+	if _, err := toml.DecodeFile(u.HomeDir+"/code/megam/go/src/github.com/megamsys/megamd/conf/megamd.conf", &cm); err != nil {
+		fmt.Println(err.Error())
 	}
 
+	c.Assert(cm, check.NotNil)
 	c.Assert(cm.Meta.Hostname, check.Equals, "localhost")
-	c.Assert(cm.Meta.Riak, check.Equals, "192.168.1.100:8087")
+	c.Assert(cm.Meta.Riak, check.DeepEquals, []string{"localhost:8087"})
 	c.Assert(cm.Meta.Api, check.Equals, "https://api.megam.io/v2")
 	c.Assert(cm.Deployd.OneEndPoint, check.Equals, "http://192.168.1.100:3030/xmlrpc2")
-	c.Assert(cm.Deployd.OneUserid, check.Equals, "onedmin")
-
+	c.Assert(cm.Deployd.OneUserid, check.Equals, "oneadmin")
 }

--- a/cmd/megamd/run/server.go
+++ b/cmd/megamd/run/server.go
@@ -2,10 +2,10 @@ package run
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"runtime"
 	"runtime/pprof"
-	"net"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
@@ -93,11 +93,11 @@ func (s *Server) Open() error {
 		// Start profiling, if set.
 		startProfile(s.CPUProfile, s.MemProfile)
 
-	/*	host, port, err := s.hostAddr()
-		if err != nil {
-			return err
-		}
-*/
+		/*	host, port, err := s.hostAddr()
+			if err != nil {
+				return err
+			}
+		*/
 		//		go s.monitorErrorChan(s.?.Err())
 
 		for _, service := range s.Services {
@@ -125,7 +125,9 @@ func (s *Server) Close() error {
 		service.Close()
 	}
 
-	close(s.closing)
+	if s.closing != nil {
+		close(s.closing)
+	}
 	return nil
 }
 

--- a/cmd/megamd/run/server_test.go
+++ b/cmd/megamd/run/server_test.go
@@ -1,154 +1,108 @@
 package run
 
+/*
+** Copyright [2013-2015] [Megam Systems]
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+** http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+ */
+
 import (
-//	"fmt"
-//	"net/http"
-//	"net/url"
-//	"strconv"
-//	"strings"
-//	"testing"
-//	"time"
+	"fmt"
+	"os/user"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/megamsys/megamd/subd/deployd"
+	"github.com/megamsys/megamd/subd/httpd"
+	"gopkg.in/check.v1"
 )
 
-
-/*
-// Ensure that HTTP responses include the InfluxDB version.
-func TestServer_HTTPResponseVersion(t *testing.T) {
-	version := "v1234"
-	s := OpenServerWithVersion(NewConfig(), version)
-	defer s.Close()
-
-	resp, _ := http.Get(s.URL() + "/query")
-	got := resp.Header.Get("X-Influxdb-Version")
-	if got != version {
-		t.Errorf("Server responded with incorrect version, exp %s, got %s", version, got)
-	}
+func Test(t *testing.T) {
+	check.TestingT(t)
 }
 
-// Ensure the database commands work.
-func TestServer_DatabaseCommands(t *testing.T) {
-	t.Parallel()
-	s := OpenServer(NewConfig(), "")
-	defer s.Close()
+type S struct {
+	srv *Server
+	cf  *Config
+}
 
-	test := Test{
-		queries: []*Query{
-			&Query{
-				name:    "create database should succeed",
-				command: `CREATE DATABASE db0`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "create database should error with bad name",
-				command: `CREATE DATABASE 0xdb0`,
-				exp:     `{"error":"error parsing query: found 0, expected identifier at line 1, char 17"}`,
-			},
-			&Query{
-				name:    "show database should succeed",
-				command: `SHOW DATABASES`,
-				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"],"values":[["db0"]]}]}]}`,
-			},
-			&Query{
-				name:    "create database should error if it already exists",
-				command: `CREATE DATABASE db0`,
-				exp:     `{"results":[{"error":"database already exists"}]}`,
-			},
-			&Query{
-				name:    "drop database should succeed",
-				command: `DROP DATABASE db0`,
-				exp:     `{"results":[{}]}`,
-			},
-			&Query{
-				name:    "show database should have no results",
-				command: `SHOW DATABASES`,
-				exp:     `{"results":[{"series":[{"name":"databases","columns":["name"]}]}]}`,
-			},
-			&Query{
-				name:    "drop database should error if it doesn't exist",
-				command: `DROP DATABASE db0`,
-				exp:     `{"results":[{"error":"database not found: db0"}]}`,
-			},
-		},
+var _ = check.Suite(&S{})
+
+// NewTestConfig returns the default config with temporary paths.
+func NewTestConfig() *Config {
+	cm := NewConfig()
+	u, _ := user.Current()
+	if _, err := toml.DecodeFile(u.HomeDir+"/code/megam/go/src/github.com/megamsys/megamd/conf/megamd.conf", cm); err != nil {
+		//if _, err := toml.DecodeFile(u.HomeDir+"./conf/megamd.conf", cm); err != nil {
+		fmt.Println(err.Error())
+		return nil
 	}
 
-	for _, query := range test.queries {
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
+	return cm
+}
+
+// OpenServer opens a test server.
+func OpenServer(c *Config) *Server {
+	s, _ := NewServer(c, "0.9.1")
+	_ = s.Open()
+	return s
+}
+
+func (s *S) SetUpSuite(c *check.C) {
+	s.cf = NewTestConfig()
+	c.Assert(s.cf, check.NotNil)
+	s.srv = OpenServer(s.cf)
+}
+
+func (s *S) TearDownSuite(c *check.C) {
+	if s.srv != nil {
+		ss := *s.srv
+		for _, service := range ss.Services {
+			service.Close()
 		}
 	}
 }
 
-func TestServer_Query_DropAndRecreateDatabase(t *testing.T) {
-	t.Parallel()
-	s := OpenServer(NewConfig(), "")
-	defer s.Close()
-
-	if err := s.CreateDatabaseAndRetentionPolicy("db0", newRetentionPolicyInfo("rp0", 1, 0)); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.MetaStore.SetDefaultRetentionPolicy("db0", "rp0"); err != nil {
-		t.Fatal(err)
-	}
-
-	writes := []string{
-		fmt.Sprintf(`cpu,host=serverA,region=uswest val=23.2 %d`, mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()),
-	}
-
-	test := NewTest("db0", "rp0")
-	test.write = strings.Join(writes, "\n")
-
-	test.addQueries([]*Query{
-		&Query{
-			name:    "Drop database after data write",
-			command: `DROP DATABASE db0`,
-			exp:     `{"results":[{}]}`,
-		},
-		&Query{
-			name:    "Recreate database",
-			command: `CREATE DATABASE db0`,
-			exp:     `{"results":[{}]}`,
-		},
-		&Query{
-			name:    "Recreate retention policy",
-			command: `CREATE RETENTION POLICY rp0 ON db0 DURATION 365d REPLICATION 1 DEFAULT`,
-			exp:     `{"results":[{}]}`,
-		},
-		&Query{
-			name:    "Show measurements after recreate",
-			command: `SHOW MEASUREMENTS`,
-			exp:     `{"results":[{}]}`,
-			params:  url.Values{"db": []string{"db0"}},
-		},
-		&Query{
-			name:    "Query data after recreate",
-			command: `SELECT * FROM cpu`,
-			exp:     `{"results":[{}]}`,
-			params:  url.Values{"db": []string{"db0"}},
-		},
-	}...)
-
-	for i, query := range test.queries {
-		if i == 0 {
-			if err := test.init(s); err != nil {
-				t.Fatalf("test init failed: %s", err)
-			}
-		}
-		if query.skip {
-			t.Logf("SKIP:: %s", query.name)
-			continue
-		}
-		if err := query.Execute(s); err != nil {
-			t.Error(query.Error(err))
-		} else if !query.success() {
-			t.Error(query.failureMessage())
-		}
-	}
+func (s *S) TestServer(c *check.C) {
+	c.Assert(s.srv, check.NotNil)
+	c.Assert(s.cf, check.NotNil)
+	ss := *s.srv
+	c.Assert(ss.Services, check.HasLen, 2)
 }
 
-*/
+// URL returns the base URL for the httpd endpoint.
+
+func (s *S) TestRabbitMQRunning(c *check.C) {
+	res := false
+	ss := *s.srv
+	for _, service := range ss.Services {
+		if _, ok := service.(*deployd.Service); ok {
+			res = true
+			break
+		}
+	}
+	c.Assert(res, check.Equals, true)
+}
+
+// URL returns the base URL for the httpd endpoint.
+func (s *S) TestHttpdRunning(c *check.C) {
+	res := false
+	ss := *s.srv
+	for _, service := range ss.Services {
+		if _, ok := service.(*httpd.Service); ok {
+			res = true
+			break
+		}
+	}
+	c.Assert(res, check.Equals, true)
+}

--- a/conf/megamd.conf
+++ b/conf/megamd.conf
@@ -48,14 +48,16 @@
   ###
   ### [docker]
   ###
-  ### Controls one or many listeners for Graphite data.
+  ### controls one or many listeners for docker
   ###
 
   [docker]
     enabled = false
     swarm = "http://192.168.1.241:2375"
 
-    [docker.public]
+  [bridges]
+
+    [bridges.public]
       name = "megdock_pub"
       network = "103.56.93.1/24"
       gateway = "103.56.92.1"

--- a/provision/box.go
+++ b/provision/box.go
@@ -51,6 +51,7 @@ type Boxlog struct {
 	Unit    string
 }
 
+
 type BoxCompute struct {
 	Cpushare string
 	Memory   string
@@ -89,6 +90,15 @@ func (bc *BoxCompute) String() string {
 		RAM + ":" + bc.Memory,
 		HDD + ":" + bc.HDD},
 		",") + " ]"
+}
+
+// Boxlog represents a log entry.
+type BoxDeploy struct {
+	Date    time.Time
+	HookId  string
+	ImageId string
+	Name    string
+	Unit    string
 }
 
 // Box represents a provision unit. Can be a machine, container or anything

--- a/provision/one/provisioner.go
+++ b/provision/one/provisioner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/megamsys/libgo/cmd"
 	"github.com/megamsys/megamd/provision"
 	"github.com/megamsys/megamd/router"
+	_ "github.com/megamsys/megamd/router/route53"
 	"github.com/megamsys/opennebula-go/api"
 )
 
@@ -92,7 +93,7 @@ func (p *oneProvisioner) StartupMessage() (string, error) {
 }
 
 func (p *oneProvisioner) GitDeploy(box *provision.Box, w io.Writer) (string, error) {
-	return "nada", nil
+	return p.deployPipeline(box, box.Repo.Git, w)
 }
 
 func (p *oneProvisioner) ImageDeploy(box *provision.Box, imageId string, w io.Writer) (string, error) {
@@ -179,7 +180,6 @@ func (p *oneProvisioner) SetState(box *provision.Box, w io.Writer, changeto prov
 	actions := []*action.Action{
 		&changeStateofMachine,
 		&addNewRoute,
-		//&addRepoHook,
 	}
 
 	pipeline := action.NewPipeline(actions...)

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -24,6 +24,7 @@ var managers map[string]RepositoryManager
 type Repo struct {
 	Enabled  bool
 	Token    string
+  SCM      string
 	Git      string
 	UserName string
 	CartonId string
@@ -33,6 +34,12 @@ type Repo struct {
 func (r Repo) IsEnabled() bool {
 	return r.Enabled
 }
+
+
+func (r Repo) GetSCM() string {
+	return r.SCM
+}
+
 
 func (r Repo) GetToken() string {
 	return r.Token
@@ -50,17 +57,18 @@ func (r Repo) GetUserName() string {
 	return r.UserName
 }
 
-func (r Repo) GetShortName(fullgit_url string) (string, error) {
-	i := strings.LastIndex(fullgit_url, "/")
+func (r Repo) GetShortName() (string, error) {
+	i := strings.LastIndex(r.Gitr(), "/")
 	if i < 0 {
 		return "", fmt.Errorf("unable to parse output of git")
 	}
-	return fullgit_url[i+1:], nil
+	return r.Gitr()[i+1:], nil
 }
 
 type Repository interface {
 	IsEnabled() bool
 	GetToken() string
+	GetSCM() string
 	Gitr() string
 	Trigger() string
 	GetUserName() string

--- a/router/route53/router.go
+++ b/router/route53/router.go
@@ -2,9 +2,11 @@ package route53
 
 import (
 	"fmt"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
 	"github.com/karlentwistle/route53"
 	"github.com/megamsys/megamd/router"
-	"strings"
 )
 
 const (
@@ -31,6 +33,7 @@ func createRouter(name string) (router.Router, error) {
 			SecretKey: "secretkey",
 		},
 	}
+	log.Debugf("%s ready", routerName)
 	return vRouter, nil
 }
 
@@ -75,7 +78,7 @@ func (r route53Router) Addr(cname string) (string, error) {
 
 	rr, err := r.zone.ResourceRecordSets(r.client)
 	if err != nil {
-		return "",err
+		return "", err
 	}
 
 	for i := range rr.ResourceRecordSets {

--- a/subd/docker/config.go
+++ b/subd/docker/config.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
-	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -40,11 +39,10 @@ const (
 )
 
 type Config struct {
-	Enabled   bool   `toml:"enabled"`
-	Registry  string `toml:"registry"`
-	Namespace string `toml:"namespace"`
-	Swarm     string `toml:"swarm"`
-	Bridges   map[string]string
+	Enabled   bool          `toml:"enabled"`
+	Registry  string        `toml:"registry"`
+	Namespace string        `toml:"namespace"`
+	Swarm     string        `toml:"swarm"`
 	MemSize   int           `toml:"mem_size"`
 	SwapSize  int           `toml:"swap_size"`
 	CPUPeriod toml.Duration `toml:"cpu_period"`
@@ -64,11 +62,6 @@ func NewConfig() *Config {
 }
 
 func (c Config) String() string {
-	bs := make([]string, len(c.Bridges))
-	for k, v := range c.Bridges {
-		bs = append(bs, k, v, "\n")
-	}
-
 	w := new(tabwriter.Writer)
 	var b bytes.Buffer
 	w.Init(&b, 0, 8, 0, '\t', 0)
@@ -77,7 +70,6 @@ func (c Config) String() string {
 	b.Write([]byte("Enabled" + "\t" + strconv.FormatBool(c.Enabled) + "\n"))
 	b.Write([]byte(DOCKER_REGISTRY + "\t" + c.Registry + "\n"))
 	b.Write([]byte(DOCKER_SWARM + "\t" + c.Swarm + "\n"))
-	b.Write([]byte("Bridges" + "\t" + strings.Join(bs, ", ") + "\n"))
 	b.Write([]byte(DOCKER_MEMSIZE + "\t" + strconv.Itoa(c.MemSize) + "\n"))
 	b.Write([]byte(DOCKER_SWAPSIZE + "\t" + strconv.Itoa(c.SwapSize) + "\n"))
 	b.Write([]byte(DOCKER_CPUPERIOD + "\t" + c.CPUPeriod.String() + "\n"))

--- a/subd/docker/config_bridges.go
+++ b/subd/docker/config_bridges.go
@@ -1,0 +1,53 @@
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/megamsys/libgo/cmd"
+)
+
+type Bridges map[string]DockerBridge
+
+type DockerBridge struct {
+	Name    string
+	Network string
+	Gateway string
+}
+
+func (d DockerBridge) String() string {
+	w := new(tabwriter.Writer)
+	var b bytes.Buffer
+	w.Init(&b, 1, 8, 0, '\t', 0)
+	b.Write([]byte(cmd.Colorfy("Bridge", "white", "", "") + "\t" +
+		cmd.Colorfy(d.Name, "blue", "", "") + "\n"))
+	b.Write([]byte("Network" + "\t" + d.Network + "\n"))
+	b.Write([]byte("Gateway" + "\t" + d.Gateway + "\n"))
+	fmt.Fprintln(w)
+	w.Flush()
+	return b.String()
+}
+
+func NewBridgeConfig() *Bridges {
+	br := make(Bridges)
+	return &br
+}
+
+func (c Bridges) String() string {
+	bs := make([]string, len(c))
+	for _, v := range c {
+		bs = append(bs, v.String(), "\n")
+	}
+
+	w := new(tabwriter.Writer)
+	var b bytes.Buffer
+	w.Init(&b, 0, 8, 0, '\t', 0)
+	b.Write([]byte(cmd.Colorfy("Config:", "white", "", "bold") + "\t" +
+		cmd.Colorfy("bridges", "green", "", "") + "\n"))
+	b.Write([]byte(strings.Join(bs, "\n") + "\n"))
+	fmt.Fprintln(w)
+	w.Flush()
+	return b.String()
+}

--- a/subd/docker/config_bridges_test.go
+++ b/subd/docker/config_bridges_test.go
@@ -1,0 +1,29 @@
+package docker
+
+import (
+	"github.com/BurntSushi/toml"
+	"gopkg.in/check.v1"
+)
+
+// Ensure the configuration can be parsed.
+func (s *S) TestDockerBrigeConfig_Parse(c *check.C) {
+	// Parse configuration.
+	var cm Bridges
+	if _, err := toml.Decode(`
+	[bridges]
+
+    [bridges.public]
+		  name = "megdock_pub"
+		  network = "103.56.93.1/24"
+		  gateway = "103.56.92.1"
+
+    [bridges.private]
+      name = "megdock_private"
+		  network = "192.168.1.128/24"
+		  gateway = "192.168.1.1"
+
+	`, &cm); err != nil {
+		c.Fatal(err)
+	}
+	c.Assert(cm, check.HasLen, 2)
+}

--- a/subd/docker/config_test.go
+++ b/subd/docker/config_test.go
@@ -11,12 +11,7 @@ func (s *S) TestDockerConfig_Parse(c *check.C) {
 	var cm Config
 	if _, err := toml.Decode(`
 	enabled = false
-	swarm = [ http://192.168.1.241:2375 ]
-
-	[docker.public]
-		name="megdock_pub"
-		network = 103.56.93.1/24
-		gateway = 103.56.92.1
+	swarm = "http://192.168.1.241:2375"
 
 	`, &cm); err != nil {
 		c.Fatal(err)


### PR DESCRIPTION
Added a method SetDeployData to support save of `hookid` as deploy data for removal during a destroy.

The `cmd` code has the tests passing. 

I tested with app/machines they run ok. We need some changes to be done in the api. Will open issues on that.

