### PR TITLE
sensor data is posted in riak periodically indexed key AccountsId_bin

### DIFF
--- a/metrix/fixtures/one.json
+++ b/metrix/fixtures/one.json
@@ -37,9 +37,10 @@
         },
         "TEMPLATE": {
           "CONTEXT": {
-            "ACCOUNTS_ID": "ACT1200099000099290465",
+            "ACCOUNTS_ID": "ACT1301557245473062912",
             "ASSEMBLIES_ID": "AMS1299290465681670144",
             "ASSEMBLY_ID": "ASM1299290465459372032",
+            "PLATFORM_ID": "PLA00001",
             "NODE_NAME": "steams.megambox.com",
             "SET_HOSTNAME": "steams.megambox.com"
           },

--- a/metrix/one.go
+++ b/metrix/one.go
@@ -54,9 +54,9 @@ func (on *OpenNebula) ParseStatus(b []byte) (ons *OpenNebulaStatus, e error) {
 func (on *OpenNebula) CollectMetricsFromStats(mc *MetricsCollection, s *OpenNebulaStatus) {
 	for _, h := range s.HISTORYS {
 		sc := NewSensor("compute.instance.exists")
+		sc.AccountsId = h.AccountsId()
 		sc.addPayload(&Payload{System: on.Prefix(),
 			Node:         h.HOSTNAME,
-			AccountsId:   h.AccountsId(),
 			AssemblyId:   h.AssemblyId(),
 			AssemblyName: h.AssemblyName(),
 			AssembliesId: h.AssembliesId(),

--- a/metrix/one_test.go
+++ b/metrix/one_test.go
@@ -15,9 +15,9 @@ func (s *S) TestParseOpenNebulaCollector(c *check.C) {
 	for _, m := range all {
 		fmt.Printf("%+v", m)
 		c.Assert(len(m.Id) > 0, check.Equals, true)
+		c.Assert(len(m.AccountsId) > 0, check.Equals, true)
 		c.Assert(len(m.Type) > 0, check.Equals, true)
 		c.Assert(len(m.CreatedAt) > 0, check.Equals, true)
-		c.Assert(len(m.Payload.AccountsId) > 0, check.Equals, true)
 		c.Assert(len(m.Payload.AssemblyId) > 0, check.Equals, true)
 		c.Assert(len(m.Payload.AssembliesId) > 0, check.Equals, true)
 		c.Assert(len(m.Payload.AssemblyName) > 0, check.Equals, true)

--- a/metrix/riak_output.go
+++ b/metrix/riak_output.go
@@ -1,7 +1,6 @@
 package metrix
 
 import (
-	"encoding/json"
 	"time"
 
 	log "github.com/Sirupsen/logrus"
@@ -11,13 +10,7 @@ import (
 func SendMetricsToRiak(address []string, metrics Sensors, hostname string) (err error) {
 	started := time.Now()
 	for _, m := range metrics {
-		sj, err := json.Marshal(m)
-		if err != nil {
-			log.Debugf(err.Error())
-			continue
-		}
-
-		if err = db.Store(SENSORSBUCKET, m.Id, sj); err != nil {
+		if err = db.Store(SENSORSBUCKET, m.Id, m); err != nil {
 			log.Debugf(err.Error())
 			continue
 		}

--- a/metrix/riak_output_test.go
+++ b/metrix/riak_output_test.go
@@ -1,0 +1,21 @@
+package metrix
+
+import (
+	"gopkg.in/check.v1"
+)
+
+func (s *S) TestStoreCollectedr(c *check.C) {
+	c.Skip("Fix: Ping riak, and then decide to skip sensors")
+
+	mh := &MetricHandler{}
+	on := &OpenNebula{RawStatus: s.testjson}
+	all, _ := mh.Collect(on)
+	c.Assert(all, check.NotNil)
+
+	o := OutputHandler{
+		RiakAddress: s.cm.Riak,
+	}
+	c.Assert(o, check.NotNil)
+	err := o.WriteMetrics(all)
+	c.Assert(err, check.IsNil)
+}

--- a/metrix/sensor.go
+++ b/metrix/sensor.go
@@ -25,10 +25,11 @@ import (
 const SENSORSBUCKET = "sensors"
 
 type Sensor struct {
-	Id        string   `json:"id"`
-	Type      string   `json:"type"`
-	Payload   *Payload `json:"payload"`
-	CreatedAt string   `json:"created_at"`
+	Id         string   `json:"id"`
+	AccountsId string   `json:"accounts" riak:"index"`
+	Type       string   `json:"type"`
+	Payload    *Payload `json:"payload"`
+	CreatedAt  string   `json:"created_at"`
 }
 
 func (s *Sensor) String() string {
@@ -38,7 +39,6 @@ func (s *Sensor) String() string {
 }
 
 type Payload struct {
-	AccountsId   string `riak:"index" json:"accounts_id"`
 	AssemblyId   string `json:"assembly_id"`
 	AssemblyName string `json:"assembly_name"`
 	AssembliesId string `json:"assemblies_id"`

--- a/metrix/suite_test.go
+++ b/metrix/suite_test.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/BurntSushi/toml"
+	"github.com/megamsys/megamd/meta"
 	"gopkg.in/check.v1"
 )
 
@@ -13,6 +15,7 @@ func Test(t *testing.T) {
 
 type S struct {
 	testjson []byte
+	cm       meta.Config
 }
 
 var _ = check.Suite(&S{})
@@ -22,4 +25,13 @@ func (s *S) SetUpSuite(c *check.C) {
 	c.Assert(e, check.IsNil)
 	s.testjson = b
 	c.Assert(s.testjson, check.NotNil)
+
+	var cm meta.Config
+	if _, err := toml.Decode(`
+	riak = ["localhost:8087"]
+	`, &cm); err != nil {
+		c.Fatal(err)
+	}
+	cm.MkGlobal()
+	s.cm = cm
 }

--- a/provision/log.go
+++ b/provision/log.go
@@ -73,7 +73,7 @@ func notify(boxName string, messages []interface{}) error {
 	defer pons.Stop()
 
 	for _, msg := range messages {
-		log.Debugf("%s:", logQueue(boxName), msg)
+		log.Debugf("%s:%s", logQueue(boxName), msg)
 		if err := pons.PublishJSONAsync(logQueue(boxName), msg, nil); err != nil {
 			log.Errorf("Error on publish: %s", err.Error())
 		}


### PR DESCRIPTION
The riak index is screwy as `golang` doesn't export `lowercase fields`. Hence the index can be queried in `gateway` using the key **AccountsId_bin**

http://localhost:8098/buckets/sensors/index/AccountsId_bin/ACT1301557245473062912
